### PR TITLE
implement --weekdays and --weekends

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ Create 1h meetings (default `--duration`) but create slots every 30m for extra f
 Many other tweaks and endless possibilities can be achieved by reading the help:
 
 ```
+> $ ./doodle.py -h                                                                         [±feat/weekdays ●●]
 usage: doodle.py [-h] [--description [DESCRIPTION]] [--after [AFTER]] [--before [BEFORE]]
-                 [--duration [DURATION]] [--slot [SLOT]] [--workdays [WORKDAYS]] [--tz [TZ]] [--maybe]
+                 [--duration [DURATION]] [--slot [SLOT]] [--weekdays] [--weekends] [--tz [TZ]] [--maybe]
                  [--dates [DATES]] [--organizer [ORGANIZER]] [--email [EMAIL]] [--notify] [--sure]
                  [--dry-run]
                  name
 
-Process some integers.
+Create DATE polls for meetings and other events, effortlessly
 
 positional arguments:
   name                  Name or topic of the meeting
@@ -54,8 +55,8 @@ optional arguments:
   --duration [DURATION]
                         Duration of the meeting in minutes
   --slot [SLOT]         Create slots set this minutes apart. By default will round duration up to hours
-  --workdays [WORKDAYS]
-                        Create meeting on workdays only
+  --weekdays            Create meeting on workdays only
+  --weekends            Create meeting on weekends only
   --tz [TZ]             Timezone
   --maybe               Allow "Yes, if need to be" answer
   --dates [DATES]       Date range [isodate|+ndays]:<isodate|+mdays>. "ndays" is relative to today, mdays to

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Create 1h meetings (default `--duration`) but create slots every 30m for extra f
 Many other tweaks and endless possibilities can be achieved by reading the help:
 
 ```
-> $ ./doodle.py -h                                                                         [±feat/weekdays ●●]
+> $ ./doodle.py -h                                                                          [±feat/weekdays ●]
 usage: doodle.py [-h] [--description [DESCRIPTION]] [--after [AFTER]] [--before [BEFORE]]
                  [--duration [DURATION]] [--slot [SLOT]] [--weekdays] [--weekends] [--tz [TZ]] [--maybe]
                  [--dates [DATES]] [--organizer [ORGANIZER]] [--email [EMAIL]] [--notify] [--sure]
@@ -55,7 +55,7 @@ optional arguments:
   --duration [DURATION]
                         Duration of the meeting in minutes
   --slot [SLOT]         Create slots set this minutes apart. By default will round duration up to hours
-  --weekdays            Create meeting on workdays only
+  --weekdays            Create meeting on weekdays only
   --weekends            Create meeting on weekends only
   --tz [TZ]             Timezone
   --maybe               Allow "Yes, if need to be" answer

--- a/doodle.py
+++ b/doodle.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument('--duration', type=int, nargs='?', default=60, help='Duration of the meeting in minutes')
     parser.add_argument('--slot', type=int, nargs='?', default=0,
                         help='Create slots set this minutes apart. By default will round duration up to hours')
-    parser.add_argument('--weekdays', action='store_true', default=False, help='Create meeting on workdays only')
+    parser.add_argument('--weekdays', action='store_true', default=False, help='Create meeting on weekdays only')
     parser.add_argument('--weekends', action='store_true', default=False, help='Create meeting on weekends only')
     parser.add_argument('--tz', type=str, nargs='?', default=os.getenv('TZ', 'Europe/Madrid'), help='Timezone')
     parser.add_argument('--maybe', action='store_true', default=False, help='Allow "Yes, if need to be" answer')


### PR DESCRIPTION
If specified, meeting slots will be generated for the specified type of day only.
Additionally, when specifying a relative end date, excluded days will not be counted in the spec:
e.g. `2020-02-05:+2 --weekdays`, where 2020-02-05 is Friday, will generate a slot on friday and another on next Monday